### PR TITLE
feat: add CacheStrategy system for fine-grained cache control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.16
+
+* Added `CacheStrategy` enum with `cacheFirst` and `networkFirst` strategies
+* New `strategy` parameter in `call()` method for fine-grained cache control
+* `networkFirst` strategy fetches fresh data and falls back to cache (even expired) on failure
+* Backward compatible: default strategy remains `cacheFirst`
+
 ## 1.0.15
 
 * Added `clearCacheByPrefix()` method to clear all cache entries matching a prefix

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A lightweight yet powerful Flutter package for caching asynchronous remote calls
 
 - ✅ **Automatic caching** of remote data with intelligent expiration
 - ⏳ **Flexible expiration** - use duration or exact datetime
+- 🎯 **Cache strategies** - choose between cache-first or network-first approaches
 - 🔄 **Manual cache invalidation** (by key, prefix, or clear all)
 - 💾 **SQLite-powered** persistent cache with automatic cleanup
 - 🧩 **Generic support** for any data type (`Map`, `List`, custom models...)
@@ -194,6 +195,43 @@ final user = await RemoteCaching.instance.call<User>(
   fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
 );
 ```
+
+### 🎯 Cache Strategies
+
+Control how data is retrieved from cache vs remote source using `CacheStrategy`:
+
+#### Cache First (Default)
+
+Uses cached data if available and valid, otherwise fetches from network. Best for data that doesn't change frequently.
+
+```dart
+final user = await RemoteCaching.instance.call<User>(
+  'user_profile_123',
+  strategy: CacheStrategy.cacheFirst, // This is the default
+  remote: () async => await apiService.getUser(123),
+  fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
+);
+```
+
+#### Network First
+
+Always tries network first, falls back to cache (even expired) if network fails. Best for data that changes frequently but should still work offline.
+
+```dart
+final news = await RemoteCaching.instance.call<News>(
+  'latest_news',
+  strategy: CacheStrategy.networkFirst,
+  remote: () async => await newsService.getLatestNews(),
+  fromJson: (json) => News.fromJson(json as Map<String, dynamic>),
+);
+```
+
+**When to use each strategy:**
+
+| Strategy | Use Case |
+|----------|----------|
+| `cacheFirst` | User profiles, settings, static content, data that rarely changes |
+| `networkFirst` | News feeds, live data, app launch when fresh data is preferred |
 
 ### 🧹 Cache Management
 
@@ -460,7 +498,7 @@ The main class for managing remote caching operations.
 | Method | Description | Parameters |
 |--------|-------------|------------|
 | `init()` | Initialize the cache system | `defaultCacheDuration`, `verboseMode`, `databasePath` |
-| `call<T>()` | Cache a remote call | `key`, `remote`, `fromJson`, `cacheDuration`, `cacheExpiring`, `forceRefresh` |
+| `call<T>()` | Cache a remote call | `key`, `remote`, `fromJson`, `cacheDuration`, `cacheExpiring`, `forceRefresh`, `strategy` |
 | `clearCache()` | Clear all cache entries | None |
 | `clearCacheForKey()` | Clear specific cache entry | `key` |
 | `clearCacheByPrefix()` | Clear all entries matching a prefix | `prefix` |
@@ -481,6 +519,18 @@ The main class for managing remote caching operations.
 - `cacheDuration` (Duration?): How long to cache the data
 - `cacheExpiring` (DateTime?): Exact expiration datetime
 - `forceRefresh` (bool): Bypass cache and fetch fresh data
+- `strategy` (CacheStrategy): Cache strategy to use (default: `CacheStrategy.cacheFirst`)
+
+### CacheStrategy Enum
+
+Controls how data is retrieved from cache vs remote source.
+
+```dart
+enum CacheStrategy {
+  cacheFirst,   // Use cache if available, otherwise fetch from network (default)
+  networkFirst, // Always try network first, fall back to cache on failure
+}
+```
 
 ### CachingStats Class
 
@@ -516,8 +566,11 @@ A: Yes! You can specify a custom database path using the `databasePath` paramete
 **Q: How do I handle cache invalidation?**
 A: Use `clearCacheForKey()` for specific entries, `clearCacheByPrefix()` for groups of related entries (e.g., all user data), or `clearCache()` for all entries. You can also use `forceRefresh: true` to bypass cache for a single call.
 
-**Q: What's the difference between `cacheDuration` and `cacheExpiring`?**  
+**Q: What's the difference between `cacheDuration` and `cacheExpiring`?**
 A: `cacheDuration` sets expiration relative to now (e.g., 30 minutes from now), while `cacheExpiring` sets an absolute expiration datetime.
+
+**Q: What's the difference between `cacheFirst` and `networkFirst` strategies?**
+A: `cacheFirst` returns cached data immediately if available (faster, less network usage). `networkFirst` always tries the network first for fresh data, falling back to cache (even expired) if the network fails. Use `cacheFirst` for static data and `networkFirst` for frequently changing data.
 
 **Q: Can I cache different types of data?**  
 A: Yes! You can cache any serializable data: primitives, maps, lists, custom objects, etc. Just provide the appropriate `fromJson` function.

--- a/lib/remote_caching.dart
+++ b/lib/remote_caching.dart
@@ -22,6 +22,7 @@
 /// ## Exported Classes and Functions
 /// - [RemoteCaching] - The main class for managing remote caching operations
 /// - [CachingStats] - Statistics about the current cache state
+/// - [CacheStrategy] - Enum for controlling cache vs network behavior
 /// - [getInMemoryDatabasePath] - Utility for creating in-memory databases (testing)
 ///
 /// For detailed documentation and examples, see the individual class documentation.
@@ -30,5 +31,6 @@ library remote_caching;
 import 'package:remote_caching/remote_caching.dart';
 
 export 'src/common/get_in_memory_database.dart' show getInMemoryDatabasePath;
+export 'src/models/cache_strategy.dart' show CacheStrategy;
 export 'src/models/caching_stats.dart' show CachingStats;
 export 'src/remote_caching_impl.dart' show RemoteCaching;

--- a/lib/src/models/cache_strategy.dart
+++ b/lib/src/models/cache_strategy.dart
@@ -1,0 +1,57 @@
+/// Defines the caching strategy for remote API calls.
+///
+/// This enum allows developers to control the behavior of how data is
+/// retrieved from cache vs remote source.
+///
+/// ## Strategies
+/// - [cacheFirst] - Uses cached data if available and valid, otherwise fetches from network.
+///   This is the default strategy and provides the fastest response time for cached data.
+/// - [networkFirst] - Always tries network first, falls back to cache if network fails.
+///   Use this when fresh data is preferred but offline support is still needed.
+///
+/// ## Example
+/// ```dart
+/// // Use cache-first strategy (default)
+/// final user = await RemoteCaching.instance.call<User>(
+///   'user_profile',
+///   strategy: CacheStrategy.cacheFirst,
+///   remote: () async => await fetchUserProfile(),
+///   fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
+/// );
+///
+/// // Use network-first strategy for fresh data
+/// final news = await RemoteCaching.instance.call<News>(
+///   'latest_news',
+///   strategy: CacheStrategy.networkFirst,
+///   remote: () async => await fetchLatestNews(),
+///   fromJson: (json) => News.fromJson(json as Map<String, dynamic>),
+/// );
+/// ```
+enum CacheStrategy {
+  /// Uses cached data if available and valid, otherwise fetches from network.
+  ///
+  /// This is the default strategy. It provides:
+  /// - Fastest response time when cache is valid
+  /// - Reduced network usage
+  /// - Works well for data that doesn't change frequently
+  ///
+  /// Flow:
+  /// 1. Check if valid cache exists
+  /// 2. If yes, return cached data immediately
+  /// 3. If no, fetch from network and cache the result
+  cacheFirst,
+
+  /// Always tries network first, falls back to cache if network fails.
+  ///
+  /// Use this strategy when:
+  /// - Fresh data is preferred
+  /// - The app should work offline when network fails
+  /// - Data changes frequently and users expect the latest version
+  ///
+  /// Flow:
+  /// 1. Try to fetch from network
+  /// 2. If successful, cache and return the data
+  /// 3. If network fails, return cached data (even if expired)
+  /// 4. If no cache exists, rethrow the network error
+  networkFirst,
+}

--- a/lib/src/remote_caching_impl.dart
+++ b/lib/src/remote_caching_impl.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart';
+import 'package:remote_caching/src/models/cache_strategy.dart';
 import 'package:remote_caching/src/models/caching_stats.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sqlite3_flutter_libs/sqlite3_flutter_libs.dart';
@@ -172,9 +173,9 @@ class RemoteCaching {
 
   /// Execute a remote call with caching.
   ///
-  /// This is the main method for caching remote API calls. It first checks
-  /// if valid cached data exists, and if not, calls the remote function
-  /// and caches the result.
+  /// This is the main method for caching remote API calls. The behavior depends
+  /// on the [strategy] parameter which controls how data is retrieved from
+  /// cache vs remote source.
   ///
   /// ## Parameters
   /// - [key] - Unique identifier for the cache entry. Use descriptive keys
@@ -188,24 +189,36 @@ class RemoteCaching {
   /// - [cacheExpiring] - Exact datetime when the cache should expire.
   ///   Cannot be used together with [cacheDuration].
   /// - [forceRefresh] - If true, bypasses cache and always calls the remote function.
+  /// - [strategy] - The caching strategy to use. Defaults to [CacheStrategy.cacheFirst].
+  ///   - [CacheStrategy.cacheFirst]: Uses cache if available, otherwise fetches from network.
+  ///   - [CacheStrategy.networkFirst]: Always tries network first, falls back to cache on failure.
   ///
   /// ## Returns
   /// The cached or freshly fetched data of type [T].
   ///
   /// ## Example
   /// ```dart
+  /// // Default cache-first strategy
   /// final user = await RemoteCaching.instance.call<User>(
   ///   'user_profile_123',
   ///   cacheDuration: Duration(minutes: 30),
   ///   remote: () async => await apiService.getUser(123),
   ///   fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
   /// );
+  ///
+  /// // Network-first strategy for fresh data with offline fallback
+  /// final news = await RemoteCaching.instance.call<News>(
+  ///   'latest_news',
+  ///   strategy: CacheStrategy.networkFirst,
+  ///   remote: () async => await newsService.getLatest(),
+  ///   fromJson: (json) => News.fromJson(json as Map<String, dynamic>),
+  /// );
   /// ```
   ///
   /// ## Throws
   /// - [StateError] if not initialized
   /// - [ArgumentError] if both [cacheDuration] and [cacheExpiring] are specified
-  /// - Any exception thrown by the [remote] function
+  /// - Any exception thrown by the [remote] function (for networkFirst, only if no cache fallback exists)
   Future<T> call<T>(
     String key, {
     required Future<T> Function() remote,
@@ -213,6 +226,7 @@ class RemoteCaching {
     Duration? cacheDuration,
     DateTime? cacheExpiring,
     bool forceRefresh = false,
+    CacheStrategy strategy = CacheStrategy.cacheFirst,
   }) async {
     if (!_isInitialized) {
       throw StateError('RemoteCaching must be initialized before use.');
@@ -227,6 +241,37 @@ class RemoteCaching {
         cacheExpiring ??
         DateTime.now().add(cacheDuration ?? _defaultCacheDuration);
 
+    switch (strategy) {
+      case CacheStrategy.cacheFirst:
+        return _executeCacheFirst<T>(
+          key,
+          remote: remote,
+          fromJson: fromJson,
+          expiresAt: expiresAt,
+          forceRefresh: forceRefresh,
+        );
+      case CacheStrategy.networkFirst:
+        return _executeNetworkFirst<T>(
+          key,
+          remote: remote,
+          fromJson: fromJson,
+          expiresAt: expiresAt,
+          forceRefresh: forceRefresh,
+        );
+    }
+  }
+
+  /// Execute cache-first strategy.
+  ///
+  /// Tries to return cached data first. If no valid cache exists,
+  /// fetches from remote and caches the result.
+  Future<T> _executeCacheFirst<T>(
+    String key, {
+    required Future<T> Function() remote,
+    required T Function(Object? json) fromJson,
+    required DateTime expiresAt,
+    required bool forceRefresh,
+  }) async {
     if (!forceRefresh) {
       final cached = await _getCachedData<T>(key, fromJson: fromJson);
       if (cached != null) {
@@ -240,6 +285,41 @@ class RemoteCaching {
     await _cacheData(key, data, expiresAt);
     _logInfo('Data cached for key: $key');
     return data;
+  }
+
+  /// Execute network-first strategy.
+  ///
+  /// Tries to fetch from remote first. If network fails, falls back to
+  /// cached data (even if expired). If no cache exists, rethrows the error.
+  Future<T> _executeNetworkFirst<T>(
+    String key, {
+    required Future<T> Function() remote,
+    required T Function(Object? json) fromJson,
+    required DateTime expiresAt,
+    required bool forceRefresh,
+  }) async {
+    try {
+      final data = await remote();
+      _logInfo('Data fetched from remote for key: $key');
+      await _cacheData(key, data, expiresAt);
+      _logInfo('Data cached for key: $key');
+      return data;
+    } catch (e, st) {
+      _logError('Network error for key $key: $e', stackTrace: st);
+
+      // Try to get cached data as fallback (even if expired)
+      final cached = await _getCachedDataWithFallback<T>(
+        key,
+        fromJson: fromJson,
+      );
+      if (cached != null) {
+        _logInfo('Falling back to cached data for key: $key');
+        return cached;
+      }
+
+      // No cache available, rethrow the original error
+      rethrow;
+    }
   }
 
   /// Get cached data if valid.
@@ -287,6 +367,44 @@ class RemoteCaching {
       }
     }
     _logInfo('No cached data found for key: $key');
+    return null;
+  }
+
+  /// Get cached data even if expired (for networkFirst fallback).
+  ///
+  /// Internal method that retrieves cached data regardless of expiration.
+  /// Used by networkFirst strategy as a fallback when network fails.
+  Future<T?> _getCachedDataWithFallback<T>(
+    String key, {
+    required T Function(Object? json) fromJson,
+  }) async {
+    final result = await _database?.query(
+      'cache',
+      where: 'key = ?',
+      whereArgs: [key],
+    );
+
+    if (result != null && result.isNotEmpty) {
+      final dataString = result.first['data']! as String;
+      try {
+        final decoded = jsonDecode(dataString);
+        try {
+          return fromJson(decoded);
+        } catch (e, st) {
+          _logError(
+            'Deserialization error (fromJson) for key $key: $e',
+            stackTrace: st,
+          );
+          return null;
+        }
+      } catch (e, st) {
+        _logError(
+          'Deserialization error (jsonDecode) for key $key: $e',
+          stackTrace: st,
+        );
+        return null;
+      }
+    }
     return null;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: remote_caching
 description: "A Flutter package for caching remote API calls with configurable duration."
-version: 1.0.15
+version: 1.0.16
 repository: https://github.com/eliatolin/remote_caching
 issue_tracker: https://github.com/eliatolin/remote_caching/issues
 topics:

--- a/test/cache_strategy_test.dart
+++ b/test/cache_strategy_test.dart
@@ -1,0 +1,260 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_caching/remote_caching.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  group('CacheStrategy Tests', () {
+    setUpAll(() async {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    });
+
+    setUp(() async {
+      await RemoteCaching.instance.init(
+        databasePath: getInMemoryDatabasePath(),
+      );
+    });
+
+    tearDown(() async {
+      await RemoteCaching.instance.clearCache();
+      await RemoteCaching.instance.dispose();
+    });
+
+    group('CacheStrategy.cacheFirst', () {
+      test('should return cached data when available', () async {
+        final testData = {'name': 'John', 'age': 30};
+        var remoteCalls = 0;
+
+        // First call - should fetch from remote (cacheFirst is default)
+        final result1 = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'cache_first_key',
+          // ignore: avoid_redundant_argument_values
+          strategy: CacheStrategy.cacheFirst,
+          remote: () async {
+            remoteCalls++;
+            return testData;
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(result1, equals(testData));
+        expect(remoteCalls, equals(1));
+
+        // Second call - should return from cache
+        final result2 = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'cache_first_key',
+          // ignore: avoid_redundant_argument_values
+          strategy: CacheStrategy.cacheFirst,
+          remote: () async {
+            remoteCalls++;
+            return {'different': 'data'};
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(Map<String, dynamic>.from(result2), equals(testData));
+        expect(remoteCalls, equals(1)); // Remote should not be called again
+      });
+
+      test('should fetch from remote when no cache exists', () async {
+        final testData = {'name': 'Jane'};
+        var remoteCalls = 0;
+
+        final result = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'no_cache_key',
+          // ignore: avoid_redundant_argument_values
+          strategy: CacheStrategy.cacheFirst,
+          remote: () async {
+            remoteCalls++;
+            return testData;
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(result, equals(testData));
+        expect(remoteCalls, equals(1));
+      });
+
+      test('should work as default strategy', () async {
+        final testData = {'value': 'default_strategy'};
+
+        // Call without specifying strategy (should default to cacheFirst)
+        final result1 = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'default_strategy_key',
+          remote: () async => testData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(result1, equals(testData));
+
+        // Second call should return cached data
+        final result2 = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'default_strategy_key',
+          remote: () async => {'different': 'data'},
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(Map<String, dynamic>.from(result2), equals(testData));
+      });
+    });
+
+    group('CacheStrategy.networkFirst', () {
+      test('should always try network first when available', () async {
+        final data1 = {'version': 1};
+        final data2 = {'version': 2};
+        var remoteCalls = 0;
+
+        // First call
+        final result1 = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'network_first_key',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async {
+            remoteCalls++;
+            return data1;
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(result1, equals(data1));
+        expect(remoteCalls, equals(1));
+
+        // Second call - should still fetch from network
+        final result2 = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'network_first_key',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async {
+            remoteCalls++;
+            return data2;
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(result2, equals(data2));
+        expect(remoteCalls, equals(2)); // Remote should be called again
+      });
+
+      test('should fall back to cache when network fails', () async {
+        final cachedData = {'cached': 'data'};
+        var remoteCalls = 0;
+
+        // First call - cache the data
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'fallback_key',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async {
+            remoteCalls++;
+            return cachedData;
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(remoteCalls, equals(1));
+
+        // Second call - network fails, should return cached data
+        final result = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'fallback_key',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async {
+            remoteCalls++;
+            throw Exception('Network error');
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(Map<String, dynamic>.from(result), equals(cachedData));
+        expect(remoteCalls, equals(2));
+      });
+
+      test('should rethrow error when network fails and no cache exists',
+          () async {
+        expect(
+          () => RemoteCaching.instance.call<Map<String, dynamic>>(
+            'no_cache_network_fail_key',
+            strategy: CacheStrategy.networkFirst,
+            remote: () async {
+              throw Exception('Network error');
+            },
+            fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+          ),
+          throwsException,
+        );
+      });
+
+      test('should fall back to expired cache when network fails', () async {
+        final cachedData = {'expired': 'data'};
+
+        // First call - cache the data with very short duration
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'expired_fallback_key',
+          cacheDuration: const Duration(milliseconds: 1),
+          strategy: CacheStrategy.networkFirst,
+          remote: () async => cachedData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // Wait for cache to expire
+        await Future.delayed(const Duration(milliseconds: 10));
+
+        // Network fails - should still return expired cached data
+        final result = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'expired_fallback_key',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async {
+            throw Exception('Network error');
+          },
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(Map<String, dynamic>.from(result), equals(cachedData));
+      });
+    });
+
+    group('Strategy comparison', () {
+      test('cacheFirst vs networkFirst behavior difference', () async {
+        final initialData = {'version': 'initial'};
+        final updatedData = {'version': 'updated'};
+
+        // Set up: Cache initial data using cacheFirst
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'comparison_cache_first',
+          // ignore: avoid_redundant_argument_values
+          strategy: CacheStrategy.cacheFirst,
+          remote: () async => initialData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'comparison_network_first',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async => initialData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // Test cacheFirst - should return cached data (initial)
+        final cacheFirstResult =
+            await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'comparison_cache_first',
+          // ignore: avoid_redundant_argument_values
+          strategy: CacheStrategy.cacheFirst,
+          remote: () async => updatedData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // Test networkFirst - should return updated data
+        final networkFirstResult =
+            await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'comparison_network_first',
+          strategy: CacheStrategy.networkFirst,
+          remote: () async => updatedData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        expect(
+          Map<String, dynamic>.from(cacheFirstResult),
+          equals(initialData),
+        ); // Returns cached
+        expect(networkFirstResult, equals(updatedData)); // Returns fresh
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements the `CacheStrategy` system as requested in #6, giving developers fine-grained control over how data is retrieved from cache vs remote source.

### Changes

- Added `CacheStrategy` enum with two strategies:
  - `cacheFirst` (default): Uses cache if available and valid, otherwise fetches from network
  - `networkFirst`: Always tries network first, falls back to cache (even expired) on failure
- Added `strategy` parameter to `call()` method
- Implemented fallback mechanism for `networkFirst` that uses expired cache data when network fails
- Added comprehensive test coverage (8 new tests)
- Updated README with usage examples, API reference, and FAQ

### Usage Example

```dart
// Network-first for fresh data with offline fallback
final news = await RemoteCaching.instance.call<News>(
  'latest_news',
  strategy: CacheStrategy.networkFirst,
  remote: () async => await newsService.getLatest(),
  fromJson: (json) => News.fromJson(json as Map<String, dynamic>),
);
```

### Backward Compatibility

- Default strategy remains `cacheFirst`, preserving existing behavior
- No breaking changes

## Test plan

- [x] All existing tests pass
- [x] New tests for `cacheFirst` strategy behavior
- [x] New tests for `networkFirst` strategy behavior
- [x] Tests for network failure fallback to cache
- [x] Tests for expired cache fallback
- [x] Flutter analyze passes with no issues

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)