### PR TITLE
feat: add onError callback for custom error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.17
+
+* Added `onError` callback to `call()` method for custom error handling
+* New `CacheError` class with detailed error information (key, type, error, stackTrace, rawData)
+* New `CacheErrorType` enum for distinguishing serialization vs deserialization errors
+* Backward compatible: errors still fallback gracefully without callback
+
 ## 1.0.16
 
 * Added `CacheStrategy` enum with `cacheFirst` and `networkFirst` strategies
@@ -27,7 +34,7 @@
 
 ## 1.0.10
 
-* Remove support for web 
+* Remove support for web
 
 ## 1.0.9
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A lightweight yet powerful Flutter package for caching asynchronous remote calls
 - 🧰 **Custom deserialization** with `fromJson` functions
 - 📊 **Cache statistics** and monitoring
 - 🧪 **Test-friendly** with verbose logging and in-memory database support
-- 🛡️ **Error handling** - graceful fallback to remote calls
+- 🛡️ **Error handling** - graceful fallback to remote calls with optional error callbacks
 - 🔧 **Cross-platform** support (iOS, Android, Desktop)
 
 ## 🎯 Why RemoteCaching?
@@ -299,7 +299,7 @@ class ProductService {
 
 ### 🛡️ Error Handling
 
-The package handles serialization errors gracefully:
+The package handles serialization errors gracefully. By default, errors are logged and the remote call is used as fallback:
 
 ```dart
 // If serialization fails, the remote call is used instead
@@ -310,6 +310,47 @@ final data = await RemoteCaching.instance.call<ComplexModel>(
   fromJson: (json) => ComplexModel.fromJson(json as Map<String, dynamic>),
 );
 ```
+
+#### Custom Error Handling with `onError`
+
+For more control over error handling, use the `onError` callback to capture and handle cache errors:
+
+```dart
+final data = await RemoteCaching.instance.call<User>(
+  'user_profile',
+  remote: () async => await fetchUser(),
+  fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
+  onError: (error) {
+    // Log to external service (Sentry, Datadog, etc.)
+    analytics.logError('cache_error', {
+      'key': error.key,
+      'type': error.type.name,
+      'message': error.message,
+    });
+
+    // Or handle specific error types
+    switch (error.type) {
+      case CacheErrorType.serialization:
+        print('Failed to save data to cache');
+        break;
+      case CacheErrorType.deserializationJson:
+        print('Cached data is corrupted');
+        break;
+      case CacheErrorType.deserializationFromJson:
+        print('Schema mismatch in cached data');
+        break;
+    }
+  },
+);
+```
+
+The `CacheError` class provides:
+- `key`: The cache key that failed
+- `type`: The type of error (`serialization`, `deserializationJson`, `deserializationFromJson`)
+- `error`: The underlying exception
+- `stackTrace`: Stack trace for debugging
+- `rawData`: The data that failed to serialize/deserialize (if available)
+- `message`: Human-readable error message
 
 ### 🔄 Cache Invalidation Strategies
 
@@ -498,7 +539,7 @@ The main class for managing remote caching operations.
 | Method | Description | Parameters |
 |--------|-------------|------------|
 | `init()` | Initialize the cache system | `defaultCacheDuration`, `verboseMode`, `databasePath` |
-| `call<T>()` | Cache a remote call | `key`, `remote`, `fromJson`, `cacheDuration`, `cacheExpiring`, `forceRefresh`, `strategy` |
+| `call<T>()` | Cache a remote call | `key`, `remote`, `fromJson`, `cacheDuration`, `cacheExpiring`, `forceRefresh`, `strategy`, `onError` |
 | `clearCache()` | Clear all cache entries | None |
 | `clearCacheForKey()` | Clear specific cache entry | `key` |
 | `clearCacheByPrefix()` | Clear all entries matching a prefix | `prefix` |
@@ -520,6 +561,7 @@ The main class for managing remote caching operations.
 - `cacheExpiring` (DateTime?): Exact expiration datetime
 - `forceRefresh` (bool): Bypass cache and fetch fresh data
 - `strategy` (CacheStrategy): Cache strategy to use (default: `CacheStrategy.cacheFirst`)
+- `onError` (void Function(CacheError)?): Callback for cache errors
 
 ### CacheStrategy Enum
 
@@ -529,6 +571,31 @@ Controls how data is retrieved from cache vs remote source.
 enum CacheStrategy {
   cacheFirst,   // Use cache if available, otherwise fetch from network (default)
   networkFirst, // Always try network first, fall back to cache on failure
+}
+```
+
+### CacheError Class
+
+Error information for cache operations.
+
+```dart
+class CacheError {
+  final String key;           // Cache key that failed
+  final CacheErrorType type;  // Type of error
+  final Object error;         // Underlying exception
+  final StackTrace stackTrace; // Stack trace
+  final Object? rawData;      // Data that failed (if available)
+  String get message;         // Human-readable error message
+}
+```
+
+### CacheErrorType Enum
+
+```dart
+enum CacheErrorType {
+  serialization,           // jsonEncode failed
+  deserializationJson,     // jsonDecode failed
+  deserializationFromJson, // fromJson function threw
 }
 ```
 
@@ -548,8 +615,11 @@ class CachingStats {
 
 ## ❓ FAQ
 
-**Q: What happens if serialization or deserialization fails?**  
-A: The error is logged, the cache is ignored, and the remote call is used. Your app will never crash due to cache errors.
+**Q: What happens if serialization or deserialization fails?**
+A: By default, the error is logged (in verbose mode), the cache is ignored, and the remote call is used. Your app will never crash due to cache errors. You can use the `onError` callback to capture and handle these errors for logging, metrics, or debugging.
+
+**Q: How can I monitor cache errors in production?**
+A: Use the `onError` callback to send errors to your analytics or monitoring service (Sentry, Datadog, etc.). The callback receives a `CacheError` object with details about the failure.
 
 **Q: Can I use my own model classes?**  
 A: Yes! Just provide a `fromJson` function and ensure your model supports `toJson` when caching. The package relies on `jsonEncode` / `jsonDecode` under the hood.

--- a/lib/remote_caching.dart
+++ b/lib/remote_caching.dart
@@ -23,6 +23,8 @@
 /// - [RemoteCaching] - The main class for managing remote caching operations
 /// - [CachingStats] - Statistics about the current cache state
 /// - [CacheStrategy] - Enum for controlling cache vs network behavior
+/// - [CacheError] - Error information for cache operations
+/// - [CacheErrorType] - Type of cache error that occurred
 /// - [getInMemoryDatabasePath] - Utility for creating in-memory databases (testing)
 ///
 /// For detailed documentation and examples, see the individual class documentation.
@@ -31,6 +33,7 @@ library remote_caching;
 import 'package:remote_caching/remote_caching.dart';
 
 export 'src/common/get_in_memory_database.dart' show getInMemoryDatabasePath;
+export 'src/models/cache_error.dart' show CacheError, CacheErrorType;
 export 'src/models/cache_strategy.dart' show CacheStrategy;
 export 'src/models/caching_stats.dart' show CachingStats;
 export 'src/remote_caching_impl.dart' show RemoteCaching;

--- a/lib/src/models/cache_error.dart
+++ b/lib/src/models/cache_error.dart
@@ -1,0 +1,82 @@
+/// Represents an error that occurred during cache operations.
+///
+/// This class provides detailed information about serialization or
+/// deserialization errors that occur during caching, allowing developers
+/// to handle them appropriately.
+///
+/// ## Example
+/// ```dart
+/// final user = await RemoteCaching.instance.call<User>(
+///   'user_profile',
+///   remote: () async => await fetchUser(),
+///   fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
+///   onError: (error) {
+///     print('Cache error for ${error.key}: ${error.message}');
+///     // Log to analytics, retry, etc.
+///   },
+/// );
+/// ```
+class CacheError {
+  /// Creates a new [CacheError] instance.
+  const CacheError({
+    required this.key,
+    required this.type,
+    required this.error,
+    required this.stackTrace,
+    this.rawData,
+  });
+
+  /// The cache key associated with this error.
+  final String key;
+
+  /// The type of cache error that occurred.
+  final CacheErrorType type;
+
+  /// The underlying error/exception that was caught.
+  final Object error;
+
+  /// The stack trace when the error occurred.
+  final StackTrace stackTrace;
+
+  /// The raw data that failed to serialize/deserialize (if available).
+  ///
+  /// For serialization errors, this is the original object.
+  /// For deserialization errors, this is the JSON string from cache.
+  final Object? rawData;
+
+  /// A human-readable message describing the error.
+  String get message {
+    switch (type) {
+      case CacheErrorType.serialization:
+        return 'Failed to serialize data for key "$key": $error';
+      case CacheErrorType.deserializationJson:
+        return 'Failed to decode JSON from cache for key "$key": $error';
+      case CacheErrorType.deserializationFromJson:
+        return 'Failed to convert JSON to object for key "$key": $error';
+    }
+  }
+
+  @override
+  String toString() => 'CacheError($message)';
+}
+
+/// The type of cache error that occurred.
+enum CacheErrorType {
+  /// Error during JSON encoding (jsonEncode failed).
+  ///
+  /// This occurs when the data returned from remote() cannot be
+  /// converted to JSON for storage in the cache.
+  serialization,
+
+  /// Error during JSON decoding (jsonDecode failed).
+  ///
+  /// This occurs when the cached JSON string cannot be parsed.
+  /// This might indicate corrupted cache data.
+  deserializationJson,
+
+  /// Error during fromJson conversion.
+  ///
+  /// This occurs when the JSON was decoded successfully but
+  /// the fromJson function threw an error during conversion.
+  deserializationFromJson,
+}

--- a/lib/src/remote_caching_impl.dart
+++ b/lib/src/remote_caching_impl.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart';
+import 'package:remote_caching/src/models/cache_error.dart';
 import 'package:remote_caching/src/models/cache_strategy.dart';
 import 'package:remote_caching/src/models/caching_stats.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -192,6 +193,12 @@ class RemoteCaching {
   /// - [strategy] - The caching strategy to use. Defaults to [CacheStrategy.cacheFirst].
   ///   - [CacheStrategy.cacheFirst]: Uses cache if available, otherwise fetches from network.
   ///   - [CacheStrategy.networkFirst]: Always tries network first, falls back to cache on failure.
+  /// - [onError] - Optional callback invoked when serialization or deserialization
+  ///   errors occur. If not provided, errors are logged (in verbose mode) and
+  ///   the remote function is called as fallback. This callback allows you to:
+  ///   - Log errors to external services (Sentry, Datadog, etc.)
+  ///   - Track metrics on cache failures
+  ///   - Debug serialization issues
   ///
   /// ## Returns
   /// The cached or freshly fetched data of type [T].
@@ -213,6 +220,20 @@ class RemoteCaching {
   ///   remote: () async => await newsService.getLatest(),
   ///   fromJson: (json) => News.fromJson(json as Map<String, dynamic>),
   /// );
+  ///
+  /// // With error handling
+  /// final data = await RemoteCaching.instance.call<Data>(
+  ///   'data_key',
+  ///   remote: () async => await fetchData(),
+  ///   fromJson: (json) => Data.fromJson(json as Map<String, dynamic>),
+  ///   onError: (error) {
+  ///     analytics.logError('cache_error', {
+  ///       'key': error.key,
+  ///       'type': error.type.name,
+  ///       'message': error.message,
+  ///     });
+  ///   },
+  /// );
   /// ```
   ///
   /// ## Throws
@@ -227,6 +248,7 @@ class RemoteCaching {
     DateTime? cacheExpiring,
     bool forceRefresh = false,
     CacheStrategy strategy = CacheStrategy.cacheFirst,
+    void Function(CacheError error)? onError,
   }) async {
     if (!_isInitialized) {
       throw StateError('RemoteCaching must be initialized before use.');
@@ -249,6 +271,7 @@ class RemoteCaching {
           fromJson: fromJson,
           expiresAt: expiresAt,
           forceRefresh: forceRefresh,
+          onError: onError,
         );
       case CacheStrategy.networkFirst:
         return _executeNetworkFirst<T>(
@@ -257,6 +280,7 @@ class RemoteCaching {
           fromJson: fromJson,
           expiresAt: expiresAt,
           forceRefresh: forceRefresh,
+          onError: onError,
         );
     }
   }
@@ -271,9 +295,14 @@ class RemoteCaching {
     required T Function(Object? json) fromJson,
     required DateTime expiresAt,
     required bool forceRefresh,
+    void Function(CacheError error)? onError,
   }) async {
     if (!forceRefresh) {
-      final cached = await _getCachedData<T>(key, fromJson: fromJson);
+      final cached = await _getCachedData<T>(
+        key,
+        fromJson: fromJson,
+        onError: onError,
+      );
       if (cached != null) {
         _logInfo('Cached data found for key: $key');
         return cached;
@@ -282,7 +311,7 @@ class RemoteCaching {
 
     final data = await remote();
     _logInfo('Data fetched from remote for key: $key');
-    await _cacheData(key, data, expiresAt);
+    await _cacheData(key, data, expiresAt, onError: onError);
     _logInfo('Data cached for key: $key');
     return data;
   }
@@ -297,11 +326,12 @@ class RemoteCaching {
     required T Function(Object? json) fromJson,
     required DateTime expiresAt,
     required bool forceRefresh,
+    void Function(CacheError error)? onError,
   }) async {
     try {
       final data = await remote();
       _logInfo('Data fetched from remote for key: $key');
-      await _cacheData(key, data, expiresAt);
+      await _cacheData(key, data, expiresAt, onError: onError);
       _logInfo('Data cached for key: $key');
       return data;
     } catch (e, st) {
@@ -311,6 +341,7 @@ class RemoteCaching {
       final cached = await _getCachedDataWithFallback<T>(
         key,
         fromJson: fromJson,
+        onError: onError,
       );
       if (cached != null) {
         _logInfo('Falling back to cached data for key: $key');
@@ -329,6 +360,7 @@ class RemoteCaching {
   Future<T?> _getCachedData<T>(
     String key, {
     required T Function(Object? json) fromJson,
+    void Function(CacheError error)? onError,
   }) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     final result = await _database?.query(
@@ -351,12 +383,30 @@ class RemoteCaching {
               'Deserialization error (fromJson) for key $key: $e',
               stackTrace: st,
             );
+            onError?.call(
+              CacheError(
+                key: key,
+                type: CacheErrorType.deserializationFromJson,
+                error: e,
+                stackTrace: st,
+                rawData: dataString,
+              ),
+            );
             return null;
           }
         } catch (e, st) {
           _logError(
             'Deserialization error (jsonDecode) for key $key: $e',
             stackTrace: st,
+          );
+          onError?.call(
+            CacheError(
+              key: key,
+              type: CacheErrorType.deserializationJson,
+              error: e,
+              stackTrace: st,
+              rawData: dataString,
+            ),
           );
           return null;
         }
@@ -377,6 +427,7 @@ class RemoteCaching {
   Future<T?> _getCachedDataWithFallback<T>(
     String key, {
     required T Function(Object? json) fromJson,
+    void Function(CacheError error)? onError,
   }) async {
     final result = await _database?.query(
       'cache',
@@ -395,12 +446,30 @@ class RemoteCaching {
             'Deserialization error (fromJson) for key $key: $e',
             stackTrace: st,
           );
+          onError?.call(
+            CacheError(
+              key: key,
+              type: CacheErrorType.deserializationFromJson,
+              error: e,
+              stackTrace: st,
+              rawData: dataString,
+            ),
+          );
           return null;
         }
       } catch (e, st) {
         _logError(
           'Deserialization error (jsonDecode) for key $key: $e',
           stackTrace: st,
+        );
+        onError?.call(
+          CacheError(
+            key: key,
+            type: CacheErrorType.deserializationJson,
+            error: e,
+            stackTrace: st,
+            rawData: dataString,
+          ),
         );
         return null;
       }
@@ -412,7 +481,12 @@ class RemoteCaching {
   ///
   /// Internal method that stores data in the cache with the specified expiration.
   /// Handles serialization errors gracefully.
-  Future<void> _cacheData<T>(String key, T data, DateTime expiresAt) async {
+  Future<void> _cacheData<T>(
+    String key,
+    T data,
+    DateTime expiresAt, {
+    void Function(CacheError error)? onError,
+  }) async {
     final now = DateTime.now();
     String? dataString;
     try {
@@ -422,7 +496,16 @@ class RemoteCaching {
         'Serialization error (jsonEncode) for key $key: $e',
         stackTrace: st,
       );
-      return; // Non salvo nulla in cache
+      onError?.call(
+        CacheError(
+          key: key,
+          type: CacheErrorType.serialization,
+          error: e,
+          stackTrace: st,
+          rawData: data,
+        ),
+      );
+      return; // Don't save anything to cache
     }
 
     await _database?.insert('cache', {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: remote_caching
 description: "A Flutter package for caching remote API calls with configurable duration."
-version: 1.0.16
+version: 1.0.17
 repository: https://github.com/eliatolin/remote_caching
 issue_tracker: https://github.com/eliatolin/remote_caching/issues
 topics:

--- a/test/error_handler_test.dart
+++ b/test/error_handler_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remote_caching/remote_caching.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  group('Error Handler Tests', () {
+    setUpAll(() async {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    });
+
+    setUp(() async {
+      await RemoteCaching.instance.init(
+        databasePath: getInMemoryDatabasePath(),
+      );
+    });
+
+    tearDown(() async {
+      await RemoteCaching.instance.clearCache();
+      await RemoteCaching.instance.dispose();
+    });
+
+    group('onError callback', () {
+      test('should be called on deserialization error (fromJson)', () async {
+        CacheError? capturedError;
+        final testData = {'name': 'John', 'age': 30};
+
+        // First call - cache the data
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'error_test_key',
+          remote: () async => testData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // Second call - fromJson throws an error
+        final result = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'error_test_key',
+          remote: () async => {'fallback': 'data'},
+          fromJson: (json) {
+            throw const FormatException('Intentional error');
+          },
+          onError: (error) {
+            capturedError = error;
+          },
+        );
+
+        // Should have captured the error
+        expect(capturedError, isNotNull);
+        expect(capturedError!.key, equals('error_test_key'));
+        expect(capturedError!.type, equals(CacheErrorType.deserializationFromJson));
+        expect(capturedError!.error, isA<FormatException>());
+        expect(capturedError!.rawData, isNotNull);
+
+        // Should have fallen back to remote
+        expect(result, equals({'fallback': 'data'}));
+      });
+
+      test('should not be called when no errors occur', () async {
+        CacheError? capturedError;
+        final testData = {'name': 'Test'};
+
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'no_error_key',
+          remote: () async => testData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+          onError: (error) {
+            capturedError = error;
+          },
+        );
+
+        expect(capturedError, isNull);
+      });
+
+      test('should work without onError callback (backward compatibility)',
+          () async {
+        final testData = {'name': 'John'};
+
+        // First call - cache the data
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'backward_compat_key',
+          remote: () async => testData,
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // Second call - fromJson throws but no onError provided
+        // Should not throw, just fall back to remote
+        final result = await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'backward_compat_key',
+          remote: () async => {'fallback': 'data'},
+          fromJson: (json) {
+            throw const FormatException('Intentional error');
+          },
+          // No onError callback - should still work
+        );
+
+        expect(result, equals({'fallback': 'data'}));
+      });
+
+      test('CacheError should have correct message for deserialization errors',
+          () async {
+        CacheError? capturedError;
+
+        // First call - cache the data
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'message_test_key',
+          remote: () async => {'data': 'test'},
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // Second call - trigger error
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'message_test_key',
+          remote: () async => {'fallback': 'data'},
+          fromJson: (json) {
+            throw const FormatException('Bad format');
+          },
+          onError: (error) {
+            capturedError = error;
+          },
+        );
+
+        expect(capturedError, isNotNull);
+        expect(
+          capturedError!.message,
+          contains('message_test_key'),
+        );
+        expect(
+          capturedError!.message,
+          contains('Bad format'),
+        );
+      });
+
+      test('CacheError toString should return readable message', () async {
+        final error = CacheError(
+          key: 'test_key',
+          type: CacheErrorType.serialization,
+          error: Exception('Test error'),
+          stackTrace: StackTrace.current,
+        );
+
+        expect(error.toString(), contains('CacheError'));
+        expect(error.toString(), contains('test_key'));
+      });
+    });
+
+    group('CacheErrorType', () {
+      test('serialization type should have correct message', () {
+        final error = CacheError(
+          key: 'key',
+          type: CacheErrorType.serialization,
+          error: Exception('error'),
+          stackTrace: StackTrace.current,
+        );
+        expect(error.message, contains('serialize'));
+      });
+
+      test('deserializationJson type should have correct message', () {
+        final error = CacheError(
+          key: 'key',
+          type: CacheErrorType.deserializationJson,
+          error: Exception('error'),
+          stackTrace: StackTrace.current,
+        );
+        expect(error.message, contains('decode JSON'));
+      });
+
+      test('deserializationFromJson type should have correct message', () {
+        final error = CacheError(
+          key: 'key',
+          type: CacheErrorType.deserializationFromJson,
+          error: Exception('error'),
+          stackTrace: StackTrace.current,
+        );
+        expect(error.message, contains('convert JSON'));
+      });
+    });
+
+    group('Error scenarios', () {
+      test('should handle multiple errors in sequence', () async {
+        final errors = <CacheError>[];
+
+        // Cache some data first
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'multi_error_key',
+          remote: () async => {'data': 'test'},
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+        );
+
+        // First error
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'multi_error_key',
+          remote: () async => {'fallback': '1'},
+          fromJson: (json) => throw Exception('Error 1'),
+          onError: errors.add,
+        );
+
+        // Cache new data
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'multi_error_key',
+          remote: () async => {'new': 'data'},
+          fromJson: (json) => Map<String, dynamic>.from(json! as Map),
+          forceRefresh: true,
+        );
+
+        // Second error
+        await RemoteCaching.instance.call<Map<String, dynamic>>(
+          'multi_error_key',
+          remote: () async => {'fallback': '2'},
+          fromJson: (json) => throw Exception('Error 2'),
+          onError: errors.add,
+        );
+
+        expect(errors.length, equals(2));
+        expect(errors[0].error.toString(), contains('Error 1'));
+        expect(errors[1].error.toString(), contains('Error 2'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements the error handler feature as requested in #4, allowing developers to capture and handle serialization/deserialization errors.

### Changes

- Added `CacheError` class with detailed error information:
  - `key`: The cache key that failed
  - `type`: Type of error (serialization, deserializationJson, deserializationFromJson)
  - `error`: The underlying exception
  - `stackTrace`: Stack trace for debugging
  - `rawData`: The data that failed (if available)
  - `message`: Human-readable error message

- Added `CacheErrorType` enum to distinguish error types

- Added `onError` callback parameter to `call()` method

### Usage Example

```dart
final data = await RemoteCaching.instance.call<User>(
  'user_profile',
  remote: () async => await fetchUser(),
  fromJson: (json) => User.fromJson(json as Map<String, dynamic>),
  onError: (error) {
    // Log to Sentry, Datadog, etc.
    analytics.logError('cache_error', {
      'key': error.key,
      'type': error.type.name,
      'message': error.message,
    });
  },
);
```

### Backward Compatibility

- No breaking changes
- If `onError` is not provided, existing silent fallback behavior is preserved
- Errors are still logged in verbose mode

## Test plan

- [x] All existing tests pass
- [x] New tests for onError callback invocation
- [x] Tests for CacheError message formatting
- [x] Tests for backward compatibility (no callback)
- [x] Flutter analyze passes with no issues

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)